### PR TITLE
Corrected ifdef/endif matching in Pong.h

### DIFF
--- a/pong/src/scenes/Pong.h
+++ b/pong/src/scenes/Pong.h
@@ -2,7 +2,7 @@
 // Created by Sterling on 3/1/2024.
 //
 
-#ifndef GAMESCENE_H
+#ifndef PONG_H
 #define PONG_H
 
 
@@ -18,4 +18,4 @@ public:
 };
 
 
-#endif //GAMESCENE_H
+#endif //PONG_H


### PR DESCRIPTION
The named guards for including the Pong.h file were incorrect; they were set as GAMESCENE_H instead of PONG_H. This guard has been updated to match the filename, preventing potential double inclusion and consequent compile errors. Thanks, CLion...